### PR TITLE
 Merge pyco_proc.py with its version from VeriFIT/smt-bench

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 .DS_Store
 
+.idea
+.venv
+__pycache__

--- a/eval_functions.py
+++ b/eval_functions.py
@@ -9,6 +9,8 @@ import io
 import os
 
 def read_latest_result_file(bench, tool):
+    assert tool != ""
+
     matching_files = []
     for root, _, files in os.walk(bench):
         for file in files:
@@ -27,6 +29,7 @@ def load_benches(benches, tools, bench_selection):
     for bench in benches:
         input = ""
         for tool in tools:
+            assert tool != ""
             input += read_latest_result_file(bench, tool)
         input = pyco_proc.proc_res(io.StringIO(input), Namespace(csv=True,html=False,text=False,tick=False,stats=None))
         df = pd.read_csv(

--- a/eval_functions.py
+++ b/eval_functions.py
@@ -28,7 +28,7 @@ def load_benches(benches, tools, bench_selection):
         input = ""
         for tool in tools:
             input += read_latest_result_file(bench, tool)
-        input = pyco_proc.proc_res(io.StringIO(input), Namespace(csv=True,html=False,text=False,tick=False))
+        input = pyco_proc.proc_res(io.StringIO(input), Namespace(csv=True,html=False,text=False,tick=False,stats=None))
         df = pd.read_csv(
                 io.StringIO(input),
                 sep=";",

--- a/eval_functions.py
+++ b/eval_functions.py
@@ -42,7 +42,7 @@ def load_benches(benches, tools, bench_selection):
 
     for tool in tools:
         # set runtime to 120 for nonsolved instances (unknown, TO, ERR or something else)
-        df_all.loc[(df_all[f"{tool}-result"] != " sat")&(df_all[f"{tool}-result"] != " unsat"), f"{tool}-runtime"] = 120
+        df_all.loc[(df_all[f"{tool}-result"] != "sat")&(df_all[f"{tool}-result"] != "unsat"), f"{tool}-runtime"] = 120
         # runtime columns should be floats
         df_all[f"{tool}-runtime"] = df_all[f"{tool}-runtime"].astype(float)
 

--- a/pyco_proc.py
+++ b/pyco_proc.py
@@ -6,14 +6,43 @@ import csv
 import sys
 from tabulate import tabulate
 import io
+from enum import Enum
+from pathlib import Path
+import datetime
+
+from z3_statistics import Z3StatisticsParser, StatsFormat
+
+#  fmt = 'text'
+fmt = 'csv'
 
 # number of parameters of execution
 __PYCO_PROC_PARAMS_NUM = 1
 
+
+class StatsDestination(Enum):
+    """Output destination for statistics."""
+    OUTPUT_FILE = "output_file"
+    SEPARATE_FILES = "separate_files"
+
+
+class RunResult(Enum):
+    """Result of a benchmark instance run."""
+    FINISHED = 1
+    ERROR = 2
+    TIMEOUT = 3
+
+
+class InnerBlockType(Enum):
+    """Type of parsed inner block."""
+    MODEL = "model"
+    STATISTICS = "statistics"
+
+
+###########################################
 def proc_res(fd, args):
     """proc_res(fd, args) -> _|_
 
-    processes results of pycobench from file descriptor 'fd' using command line
+    processes results of pycobench.py from file descriptor 'fd' using command line
     arguments 'args'
 """
     reader = csv.reader(
@@ -23,6 +52,11 @@ def proc_res(fd, args):
     engines = list()
     engines_outs = dict()
     results = dict()
+
+    current_time = datetime.datetime.now().strftime("%Y-%m-%d-%H-%M-%S")
+    if args.stats and args.stats == StatsDestination.SEPARATE_FILES:
+        Path(f"./stats/{current_time}/").mkdir(parents=True, exist_ok=True)
+
     for row in reader:
         assert len(row) >= 1 + 1 + __PYCO_PROC_PARAMS_NUM  # status + engine name + params
         status, eng = row[0], row[1]
@@ -32,7 +66,8 @@ def proc_res(fd, args):
             results[params] = dict()
         if eng not in engines:
             engines.append(eng)
-            engines_outs[eng] = ["result"]
+            engines_outs[eng] = list()
+            # engines_outs[eng] = ["result"]
 
         # we don't have some results twice
         assert eng not in results[params]
@@ -46,25 +81,57 @@ def proc_res(fd, args):
             eng_res["retcode"] = retcode
             eng_res["error"] = err
             eng_res["output"] = dict()
+            eng_res["run_result"] = RunResult.FINISHED
+            name = ""
 
-            out_lines = [out]
+            # out_lines = [out]
+            out_lines = out.split("###")
+            inner_block_type: None | InnerBlockType = None
+            inner_block = ""
             for line in out_lines:
-                spl = line.split(':', 1)
-                if len(spl) != 2:  # jump over lines not in the format
-                    continue
-                name, val = spl[0], spl[1]
-                if name != 'result':
-                    # sys.stderr.write(f"Warning: line in wrong format: {spl}\n")
-                    continue
-                eng_res["output"][name] = val
+                if inner_block_type:
+                    inner_block += line + "\n"
+
+                    if line.endswith(")"):
+                        if inner_block_type == InnerBlockType.STATISTICS:
+                            engine_stats_name = "stats"
+                            assert engine_stats_name not in eng_res["output"]
+                            if engine_stats_name not in engines_outs[eng]:
+                                engines_outs[eng].append(engine_stats_name)
+                            eng_res["output"][engine_stats_name] = Z3StatisticsParser(inner_block).stats
+                        elif inner_block_type == InnerBlockType.MODEL:
+                            # TODO: Add model block handling.
+                            # print("model:")
+                            # print(inner_block)
+                            pass
+
+                        inner_block = ""
+                        inner_block_type = None
+                elif line.startswith("(:"):
+                    inner_block_type = InnerBlockType.STATISTICS
+                    inner_block += line + "\n"
+                elif line == "(":
+                    inner_block_type = InnerBlockType.MODEL
+                    inner_block += line + "\n"
+                else:
+                    spl = line.split(':', 1)
+                    if len(spl) != 2:  # jump over lines not in the format
+                        continue
+                    name, val = spl[0].strip(), spl[1].strip()
+
+                    assert name not in eng_res["output"]
+                    if name not in engines_outs[eng]:
+                        engines_outs[eng].append(name)
+                    eng_res["output"][name] = val
 
             results[params][eng] = eng_res
+        elif status == 'error':
+            results[params][eng] = {}
+            results[params][eng]["run_result"] = RunResult.ERROR
+        elif status == 'timeout':
+            results[params][eng] = {}
+            results[params][eng]["run_result"] = RunResult.TIMEOUT
 
-        if status == 'error':
-            results[params][eng] = "ERR"
-
-        if status == 'timeout':
-            results[params][eng] = "TO"
 
     list_ptrns = list()
     for bench in results:
@@ -74,10 +141,15 @@ def proc_res(fd, args):
             out_len = len(engines_outs[eng]) + 1    # +1 = time
             if eng in results[bench]:
                 bench_res = results[bench][eng]
-                if bench_res == "ERR":
+                for out in engines_outs[eng]:
+                    if out == "stats":
+                        bench_res["output"][out] = \
+                            Z3StatisticsParser.stats_formatter(bench_res["output"][out], args.stats_format)
+
+                if bench_res["run_result"] == RunResult.ERROR:
                     for i in range(out_len):
                         ls.append("ERR")
-                elif bench_res == "TO":
+                elif bench_res["run_result"] == RunResult.TIMEOUT:
                     for i in range(out_len):
                         ls.append("TO")
                 else:
@@ -87,11 +159,23 @@ def proc_res(fd, args):
                     ls.append(bench_res["runtime"])
                     for out in engines_outs[eng]:
                         if out in bench_res["output"]:
-                            ls.append(bench_res["output"][out])
+                            out_data = bench_res["output"][out]
+
+                            if out == "stats":
+                                if args.stats == StatsDestination.SEPARATE_FILES:
+                                    stats_file_name = f"{eng}-{bench[0].replace('/', '_').replace('.', '_')}-stats.json"
+                                    with open(f"./stats/{current_time}/{stats_file_name}", "w") as f:
+                                        f.write(out_data)
+                                elif args.stats == StatsDestination.OUTPUT_FILE:
+                                    if args.csv:
+                                       out_data = out_data.replace("\n", "###")
+                                    ls.append(out_data)
+                            else:
+                                ls.append(out_data)
+
                         else:
-                            # sys.stderr.write("Warning: in {} and {}: "
-                            #     "element {} not in {}\n".format(bench, eng,
-                            #     out, bench_res["output"]))
+                            sys.stderr.write(f"Warning: in {bench} and {eng}: element {out} not in "
+                                             f"{bench_res['output']}\n")
                             ls.append("MISSING")
                             # assert False
             else:
@@ -116,7 +200,10 @@ def proc_res(fd, args):
     for eng in engines:
         header += [eng + "-runtime"]
         for out in engines_outs[eng]:
-            header += [eng + "-result"]
+            if out == "stats" and args.stats != StatsDestination.OUTPUT_FILE:
+                continue
+            header += [eng + "-" + out]
+            # header += [eng + "-result"]
 
     fmt = "text"
     if args.csv:
@@ -140,14 +227,14 @@ def proc_res(fd, args):
         return output.getvalue()
     else:
         raise Exception('Invalid output format: "{}"'.format(fmt))
-    return
 
-if __name__ == '__main__':
-    parser = argparse.ArgumentParser(description='''proc_results.py - \
-Processes results of benchmarks from pycobench''')
-    parser.add_argument('results', metavar='result-file', nargs='?',
-                        help='file with results (output of pycobench);'
-                             'if not provided stdin is used')
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Processes results of benchmarks from pycobench.py")
+    parser.add_argument('result_file', nargs='?',
+                        help='file with results (output of pycobench.py) (default: \'<stdin>\')',
+                        type=argparse.FileType('r'), default=sys.stdin)
+    parser.add_argument("-o", "--output", help="Output file to print the parsed results (default: \'<stdout>\')", nargs="?", type=argparse.FileType('w'), default=sys.stdout)
     parser.add_argument('--csv', action="store_true",
                         help='output in CSV')
     parser.add_argument('--text', action="store_true",
@@ -156,13 +243,27 @@ Processes results of benchmarks from pycobench''')
                         help='output in HTML')
     parser.add_argument('--tick', action="store_true",
                         help='tick finished benchmarks (usable for filtering)')
+    parser.add_argument('--stats-format',
+                        choices=list(format_option.name.lower() for format_option in StatsFormat), 
+                        default=StatsFormat.JSON.value,
+                        help='Which format to use for printing statistics (default: \'%(default)s\')')
+    parser.add_argument('--stats', nargs='?',
+                        choices=list(destination_option.name.lower() for destination_option in StatsDestination),
+                        const="output_file", default=None,
+                        help='Whether to output statistics and where (default: skipping stats, flag without \
+                              argument: \'%(const)s\')')
     args = parser.parse_args()
 
-    if args.results:
-        fd = open(args.results, "r")
-    else:
-        fd = sys.stdin
+    if args.stats:
+        args.stats = StatsDestination[args.stats.upper()]
+    if args.stats_format:
+        args.stats_format = StatsFormat[args.stats_format.upper()]
 
-    print(proc_res(fd, args, sys.stdout))
-    if args.results:
-        fd.close()
+    return args
+
+
+###############################
+if __name__ == '__main__':
+    args = parse_args()
+    processed_results = proc_res(args.result_file, args)
+    args.output.write(processed_results)

--- a/pyco_proc.py
+++ b/pyco_proc.py
@@ -85,7 +85,12 @@ def proc_res(fd, args):
             name = ""
 
             # out_lines = [out]
-            out_lines = out.split("###")
+            out_lines = []
+            lines = out.split("###")
+            for line in lines:
+                if "WARNING" in line:
+                    continue
+                out_lines.append(line)
             inner_block_type: None | InnerBlockType = None
             inner_block = ""
             for line in out_lines:

--- a/z3_statistics.py
+++ b/z3_statistics.py
@@ -1,0 +1,80 @@
+#!/usr/bin/env python3
+
+import sys
+import argparse
+import json
+import io
+from enum import Enum
+
+
+class StatsFormat(Enum):
+    JSON = "json"
+    # HTML = "html"
+    # CSV = "csv"
+    # TSV = "tsv"
+
+
+class Z3StatisticsParser:
+    def __init__(self, input_data: str | bytes):
+        self._input_data: list[str] = input_data.splitlines()
+        self._stats: dict = {}
+
+        self.__parse_statistics()
+
+    @staticmethod
+    def stats_formatter(stats: dict, format: StatsFormat = StatsFormat.JSON) -> str:
+        if format == StatsFormat.JSON:
+            return json.dumps(stats, indent=2, sort_keys=True)
+    
+    @staticmethod
+    def __decode_stat_value(value: str) -> int | float | str:
+        valid_value_types = [int, float, str]
+        for value_type_conversion_function in valid_value_types:
+            try:
+                result = value_type_conversion_function(value)
+            except ValueError:
+                continue
+        return value
+
+    def __parse_statistics(self) -> None:
+        reading_stats = False
+        for line in self._input_data:
+            if not reading_stats and line.startswith("(:"):
+                reading_stats = True
+
+            if reading_stats:
+                if line.endswith(")"):
+                    reading_stats = False
+                line = line.replace("(", "").replace(")", "").replace(":", "").split()
+                self._stats[line[0]] = (self.__decode_stat_value(line[1]))
+
+    @property
+    def stats(self) -> dict:
+        return self._stats
+
+    def print_stats(self, stats_file: io.TextIOWrapper, format: StatsFormat = StatsFormat.JSON) -> None:
+        formatted_stats = Z3StatisticsParser.stats_formatter(stats=self.stats, format=format)
+        formatted_stats += "\n"
+        stats_file.write(formatted_stats)
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Z3 statistics parser")
+    parser.add_argument("statistics_file", help="File with Z3 output with statistics to parse (default: \'<stdin>\')", nargs="?", type=argparse.FileType('r'), default=sys.stdin)
+    parser.add_argument("-o", "--output", help="Output file to print the parsed Z3 statistics (default: \'<stdout>\')", nargs="?", type=argparse.FileType('w'), default=sys.stdout)
+    parser.add_argument('--format',
+                        choices=list(format_option.name.lower() for format_option in StatsFormat),
+                        default=StatsFormat.JSON.value,
+                        help='Which format to use for printing statistics (default: \'%(default)s\')')
+    args = parser.parse_args()
+
+    if args.format:
+        args.format = StatsFormat[args.format.upper()]
+
+    return args
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    Z3StatisticsParser(input_data=args.statistics_file.read()) \
+        .print_stats(stats_file=args.output, format=args.format)


### PR DESCRIPTION
This PR tries to merge pyco_proc.py with its version in VeriFIT/smt-string-bench-results. It seems that there are some issues that we will have to figure out on the go. From the data I gathered, this should be how it should work, even for OSTRICH. I need someone to try all the usual operations and see whether something breaks.

The commented-out lines represent some of the changes in VeriFIT/smt-string-bench-results which might be relevant for fixing potential new bugs.

Modifying the eval.ipynb is the next step. I will be slowly working on it while working on my current PhD Talent proposal.